### PR TITLE
More Intuitive Date Selection on Date Picker

### DIFF
--- a/functions/date-picker/date-picker.js
+++ b/functions/date-picker/date-picker.js
@@ -72,6 +72,15 @@ class DatePicker {
     setupEventListeners() {
         // Show calendar when input is clicked
         this.dateInput.addEventListener('click', () => {
+            // If there's a selected date, open to that month; otherwise open to current month
+            if (this.selectedDate) {
+                this.currentMonth = this.selectedDate.getMonth();
+                this.currentYear = this.selectedDate.getFullYear();
+            } else {
+                this.currentMonth = new Date().getMonth();
+                this.currentYear = new Date().getFullYear();
+            }
+            
             this.calendar.style.display = 'block';
             this.renderCalendar();
             


### PR DESCRIPTION
Date picker used to open up to the month last viewed by the user in the current session, even if a date in that month hadn't been selected.

Updated the logic so that if the date picker is empty, open it with the current month displayed, or if a date is already selected, open the date picker to the month of that date.