### PR TITLE
Migrate to Spotify API March 2026 endpoints

### DIFF
--- a/admin/playlist-manager/documentation/SPOTIFY_API_MIGRATION_MARCH_2026.md
+++ b/admin/playlist-manager/documentation/SPOTIFY_API_MIGRATION_MARCH_2026.md
@@ -1,0 +1,138 @@
+# Spotify API Migration - March 2026 Changes
+
+## Impact Assessment: YES, Changes Required ⚠️
+
+The February 2026 Spotify API changes **will impact** the Urban Swing Playlist Manager starting **March 9, 2026**.
+
+---
+
+## Critical Changes Affecting This App
+
+### 1. Endpoint Migrations (REQUIRED)
+
+The following endpoints used by the Playlist Manager are being **removed** and must be replaced:
+
+#### ❌ Deprecated → ✅ New Endpoint
+
+| Current (Deprecated) | New Endpoint | Used In |
+|---------------------|--------------|---------|
+| `POST /users/{id}/playlists` | `POST /me/playlists` | [spotify-api.js](../spotify-api.js#L234) |
+| `GET /playlists/{id}/tracks` | `GET /playlists/{id}/items` | [spotify-api.js](../spotify-api.js#L259) |
+| `POST /playlists/{id}/tracks` | `POST /playlists/{id}/items` | [spotify-api.js](../spotify-api.js#L364) |
+| `DELETE /playlists/{id}/tracks` | `DELETE /playlists/{id}/items` | [spotify-api.js](../spotify-api.js#L373) |
+| `PUT /playlists/{id}/tracks` | `PUT /playlists/{id}/items` | [spotify-api.js](../spotify-api.js#L356) |
+| `DELETE /playlists/{id}/followers` | `DELETE /me/library` | [spotify-api.js](../spotify-api.js#L461) |
+
+### 2. Field Name Changes
+
+**Playlist Object:**
+- `tracks` → renamed to `items`
+- `tracks.tracks` → `items.items`
+- `tracks.tracks.track` → `items.items.item`
+
+**User Object (Removed Fields):**
+- `email` - No longer available
+- `country` - No longer available
+- `product` - No longer available (can't check if user has Premium)
+
+### 3. Search Limit Changes
+
+**Search endpoint (`GET /search`):**
+- Old: `limit` max = 50, default = 20
+- New: `limit` max = 10, default = 5
+
+Current code uses `limit=20` in [spotify-api.js](../spotify-api.js#L429), which will need adjustment.
+
+---
+
+## Development Mode Restrictions
+
+Starting **March 9, 2026**, all Development Mode apps will have these restrictions:
+
+### New Requirements:
+1. **Spotify Premium Required** - The main account holder (developer) must have Spotify Premium
+2. **One Client ID per Developer** - Limited to 1 Development Mode app
+3. **Max 5 Authorized Users** - Only 5 people can use the app
+4. **Restricted Endpoints** - Limited to specific endpoints (but most playlist endpoints are still available)
+
+### ✅ GOOD NEWS: Extended Quota Mode Apps Are Exempt
+
+From the email:
+> **Note:** *These changes do not affect apps already operating in Extended Quota Mode.*
+
+**If your app is already approved for Extended Quota Mode, you're exempt from these restrictions.**
+
+However, you **still need to update the deprecated endpoints** - those changes apply to all apps.
+
+---
+
+## Migration Checklist
+
+### Before March 9, 2026:
+
+- [ ] **Update all deprecated endpoints** to new versions
+- [ ] **Update field references** from `tracks` to `items`
+- [ ] **Adjust search limit** from 20 to max 10
+- [ ] **Test with new endpoints** to ensure functionality
+- [ ] **Verify Development Mode vs Extended Quota Mode status**
+
+### Check Your App Status:
+
+1. Go to [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
+2. Select your app
+3. Check if it says:
+   - "Development Mode" → You'll need Premium + limited to 5 users
+   - "Extended Quota Mode" → You're exempt from restrictions (but still need endpoint updates)
+
+---
+
+## Migration Priority: HIGH
+
+**Deadline:** March 9, 2026
+
+**Risk Level:** 🔴 **High** - App will break if not updated
+
+**Estimated Work:** 2-3 hours for code updates + testing
+
+---
+
+## Code Changes Required
+
+### Files to Update:
+
+1. **[spotify-api.js](../spotify-api.js)** - All endpoint URLs
+2. **[playlist-display.js](../playlists/playlist-display.js)** - Check for `tracks` vs `items` references
+3. **[cloudflare-worker/worker.js](../../../cloudflare-worker/worker.js)** - If it stores user data
+
+### Testing Checklist:
+
+- [ ] Create new playlist
+- [ ] Get playlist tracks/items
+- [ ] Add tracks/items to playlist
+- [ ] Remove tracks/items from playlist
+- [ ] Reorder tracks/items in playlist
+- [ ] Delete (unfollow) playlist
+- [ ] Search for tracks
+- [ ] Full workflow test
+
+---
+
+## References
+
+- [February 2026 Changes](https://developer.spotify.com/documentation/web-api/references/changes/february-2026)
+- [Migration Guide](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide)
+- [Developer Blog Announcement](https://developer.spotify.com/blog/2026-02-06-update-on-developer-access-and-platform-security)
+
+---
+
+## Next Steps
+
+1. **Determine your app's quota mode status** (Development vs Extended)
+2. **Schedule migration work** (before March 9, 2026)
+3. **Update code** following this document
+4. **Test thoroughly** with all playlist operations
+5. **Monitor for any API errors** after March 9
+
+---
+
+*Last Updated: February 27, 2026*

--- a/admin/playlist-manager/mobile-playlist-selector.js
+++ b/admin/playlist-manager/mobile-playlist-selector.js
@@ -121,7 +121,7 @@ export function populateMobilePlaylistList(playlists, selectedPlaylistId) {
         <img src="${imageUrl}" alt="${playlist.name}">
         <div class="playlist-info">
           <p class="playlist-name">${playlist.name}</p>
-          <p class="playlist-tracks">${playlist.tracks?.total || 0} tracks • ${formattedDuration}</p>
+          <p class="playlist-tracks">${playlist.items?.total || 0} tracks • ${formattedDuration}</p>
         </div>
       </a>
     `;

--- a/admin/playlist-manager/playlists/playlist-display.js
+++ b/admin/playlist-manager/playlists/playlist-display.js
@@ -161,7 +161,7 @@ export function displayPlaylists(playlists) {
         <img src="${imageUrl}" alt="${playlist.name}">
         <div class="playlist-item-info">
           <div class="playlist-item-name">${playlist.name}</div>
-          <div class="playlist-item-count">${playlist.tracks.total} tracks • <span class="playlist-item-duration">${formattedDuration}</span></div>
+          <div class="playlist-item-count">${playlist.items.total} tracks • <span class="playlist-item-duration">${formattedDuration}</span></div>
         </div>
         <div class="playlist-item-actions">
           <button class="playlist-menu-btn" data-playlist-id="${playlist.id}">
@@ -358,7 +358,7 @@ export async function updatePlaylistTrackCount(playlistId, delta, trackDuration 
   
   if (playlist) {
     // Update the count
-    playlist.tracks.total += delta;
+    playlist.items.total += delta;
     
     // Update the duration if provided
     if (trackDuration) {
@@ -375,7 +375,7 @@ export async function updatePlaylistTrackCount(playlistId, delta, trackDuration 
     if (playlistItem) {
       const countEl = playlistItem.querySelector('.playlist-item-count');
       if (countEl) {
-        countEl.innerHTML = `${playlist.tracks.total} tracks • <span class="playlist-item-duration">${formattedDuration}</span>`;
+        countEl.innerHTML = `${playlist.items.total} tracks • <span class="playlist-item-duration">${formattedDuration}</span>`;
       }
     }
     
@@ -384,7 +384,7 @@ export async function updatePlaylistTrackCount(playlistId, delta, trackDuration 
     if (mobilePlaylistItem) {
       const mobileCountEl = mobilePlaylistItem.querySelector('.playlist-tracks');
       if (mobileCountEl) {
-        mobileCountEl.innerHTML = `${playlist.tracks.total} tracks • <span class="playlist-item-duration">${formattedDuration}</span>`;
+        mobileCountEl.innerHTML = `${playlist.items.total} tracks • <span class="playlist-item-duration">${formattedDuration}</span>`;
       }
     }
   }

--- a/admin/playlist-manager/playlists/playlist-selection.js
+++ b/admin/playlist-manager/playlists/playlist-selection.js
@@ -62,7 +62,7 @@ export async function performPlaylistSelection(playlist) {
   document.getElementById('playlist-image').src = imageUrl;
   document.getElementById('playlist-name').textContent = playlist.name;
   document.getElementById('playlist-description').textContent = playlist.description || 'No description';
-  document.getElementById('playlist-track-count').textContent = playlist.tracks.total;
+  document.getElementById('playlist-track-count').textContent = playlist.items.total;
   
   // Load tracks (will be imported from track-operations)
   await loadTracks(playlist.id);

--- a/admin/playlist-manager/tracks/track-add-modal.js
+++ b/admin/playlist-manager/tracks/track-add-modal.js
@@ -73,7 +73,7 @@ async function searchAndDisplayTracks(query) {
   try {
     resultsContainer.innerHTML = '<div class="loading-pulse" style="padding: 20px; text-align: center;">Searching...</div>';
     
-    const tracks = await spotifyAPI.searchTracks(query, 20);
+    const tracks = await spotifyAPI.searchTracks(query, 10);
     console.log('Search results:', tracks);
     console.log('🎵 Enhanced search rendering active - play buttons and selected tracks reordering');
     

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -81,7 +81,9 @@ async function exchangeToken(request, env) {
       fields: {
         refreshToken: { stringValue: tokens.refresh_token },
         spotifyUserId: { stringValue: userId },
-        spotifyEmail: { stringValue: spotifyUser.email || '' },
+        // Note: spotifyUser.email removed from Spotify API (March 2026)
+        // Display name is still available as a fallback identifier
+        spotifyDisplayName: { stringValue: spotifyUser.display_name || '' },
         lastUpdated: { timestampValue: new Date().toISOString() },
       },
     };


### PR DESCRIPTION
- Updated playlist endpoints from /tracks to /items
- Migrated createPlaylist to POST /me/playlists
- Migrated deletePlaylist to DELETE /me/library (query param)
- Fixed body parameters: tracksitems for remove operation
- Updated field references: playlist.tracks.totalitems.total
- Reduced search limit from 20 to 10 (new max)
- Updated worker.js: replaced email with displayName