### PR TITLE
Lock active concessions

### DIFF
--- a/admin/student-database/js/concessions/concessions-detail-modal.js
+++ b/admin/student-database/js/concessions/concessions-detail-modal.js
@@ -106,6 +106,10 @@ function buildConcessionSection(title, count, blocks, status) {
             iconColor = 'var(--text-muted)';
     }
     
+    // Check if any blocks in this section are locked
+    const hasLockedBlocks = blocks.some(block => block.isLocked === true);
+    const lockedBadge = hasLockedBlocks ? '<span class="badge badge-locked" style="margin-left: 8px;"><i class="fas fa-lock"></i> LOCKED</span>' : '';
+    
     // Active sections are expanded by default, others are collapsed
     const isExpanded = status === 'active';
     const accordionId = `concession-accordion-${status}`;
@@ -113,7 +117,7 @@ function buildConcessionSection(title, count, blocks, status) {
     let html = `
         <div class="concessions-section">
             <h4 class="concession-accordion-header ${isExpanded ? 'active' : ''}" data-target="${accordionId}">
-                <i class="fas ${icon}" style="color: ${iconColor};"></i> ${title} (${count})
+                <i class="fas ${icon}" style="color: ${iconColor};"></i> ${title} (${count}) ${lockedBadge}
                 <i class="fas fa-chevron-down accordion-icon"></i>
             </h4>
             <div id="${accordionId}" class="concessions-list accordion-content ${isExpanded ? 'show' : ''}">
@@ -196,12 +200,7 @@ function buildConcessionItem(block, status) {
 function buildLockButton(block, status) {
     const isLocked = block.isLocked === true;
     
-    if (status === 'active') {
-        // Active blocks cannot be locked/unlocked
-        return `<button class="btn-cancel" disabled title="Cannot lock/unlock active concessions"><i class="fas fa-lock"></i> Lock</button>`;
-    }
-    
-    // Expired and depleted blocks can be locked/unlocked (only by super admin)
+    // Only super admin can lock/unlock blocks
     if (!isSuperAdmin()) {
         return '';
     }

--- a/admin/student-database/js/concessions/concessions-detail-modal.js
+++ b/admin/student-database/js/concessions/concessions-detail-modal.js
@@ -150,6 +150,10 @@ function buildConcessionItem(block, status) {
     const lockButton = buildLockButton(block, status);
     const deleteButton = buildDeleteButton(block, hasBeenUsed);
     
+    // Get existing notes for locked blocks (any status) or expired/depleted items
+    const existingNotes = block.lockNotes || '';
+    const showNotes = isLocked || status === 'expired' || status === 'depleted';
+    
     // Set labels and icons based on status
     let expiryLabel, expiryIcon, entriesLabel, statusClass;
     
@@ -185,6 +189,18 @@ function buildConcessionItem(block, status) {
                 <span><i class="fas ${expiryIcon}"></i> ${expiryLabel}: ${formatDate(expiryDate)}</span>
                 <span><i class="fas fa-shopping-cart"></i> Purchased: ${formatDate(purchaseDate)}</span>
             </div>
+            ${showNotes ? `
+            <div class="concession-notes">
+                <label for="notes-${block.id}">Notes:</label>
+                <textarea 
+                    id="notes-${block.id}" 
+                    class="concession-notes-input" 
+                    data-block-id="${block.id}"
+                    placeholder="Add notes about why this concession is locked/unlocked..."
+                    rows="3">${existingNotes}</textarea>
+                <span class="notes-save-status" id="notes-status-${block.id}"></span>
+            </div>
+            ` : ''}
             <div class="concession-actions">
                 ${buildEditExpiryButton(block, status)}
                 ${lockButton}
@@ -304,6 +320,49 @@ function attachConcessionDetailEventListeners(contentEl, studentId) {
                 showDeleteConfirmationModal(blockId, studentId);
             });
         }
+    });
+    
+    // Notes input - auto-save with debounce
+    const notesDebounceTimers = {};
+    contentEl.querySelectorAll('.concession-notes-input').forEach(textarea => {
+        textarea.addEventListener('input', (e) => {
+            const blockId = textarea.dataset.blockId;
+            const notes = textarea.value;
+            const statusEl = document.getElementById(`notes-status-${blockId}`);
+            
+            // Clear existing timer for this textarea
+            if (notesDebounceTimers[blockId]) {
+                clearTimeout(notesDebounceTimers[blockId]);
+            }
+            
+            // Show "saving..." indicator
+            if (statusEl) {
+                statusEl.textContent = 'Saving...';
+                statusEl.className = 'notes-save-status saving';
+            }
+            
+            // Set new timer to save after user stops typing (1 second delay)
+            notesDebounceTimers[blockId] = setTimeout(async () => {
+                try {
+                    await updateConcessionBlockNotes(blockId, notes);
+                    if (statusEl) {
+                        statusEl.textContent = 'Saved';
+                        statusEl.className = 'notes-save-status saved';
+                        // Clear the saved message after 2 seconds
+                        setTimeout(() => {
+                            statusEl.textContent = '';
+                            statusEl.className = 'notes-save-status';
+                        }, 2000);
+                    }
+                } catch (error) {
+                    console.error('Error saving notes:', error);
+                    if (statusEl) {
+                        statusEl.textContent = 'Error saving';
+                        statusEl.className = 'notes-save-status error';
+                    }
+                }
+            }, 1000);
+        });
     });
     
     // Lock all expired button

--- a/admin/student-database/js/transaction-history/transaction-history-concessions.js
+++ b/admin/student-database/js/transaction-history/transaction-history-concessions.js
@@ -115,12 +115,16 @@ function buildTransactionConcessionSection(title, count, blocks, status, student
             iconColor = 'var(--text-muted)';
     }
     
+    // Check if any blocks in this section are locked
+    const hasLockedBlocks = blocks.some(block => block.isLocked === true);
+    const lockedBadge = hasLockedBlocks ? '<span class="badge badge-locked" style="margin-left: 8px;"><i class="fas fa-lock"></i> LOCKED</span>' : '';
+    
     const accordionId = `transaction-concession-accordion-${status}`;
     
     let html = `
         <div class="concessions-section">
             <h4 class="concession-accordion-header ${isExpanded ? 'active' : ''}" data-target="${accordionId}">
-                <i class="fas ${icon}" style="color: ${iconColor};"></i> ${title} (${count})
+                <i class="fas ${icon}" style="color: ${iconColor};"></i> ${title} (${count}) ${lockedBadge}
                 <i class="fas fa-chevron-down accordion-icon"></i>
             </h4>
             <div id="${accordionId}" class="concessions-list accordion-content ${isExpanded ? 'show' : ''}">
@@ -161,21 +165,20 @@ function buildTransactionConcessionItem(block, status, studentId) {
         editExpiryButton = `<button class="btn-primary" data-block-id="${block.id}" data-student-id="${studentId}" data-current-expiry="${currentExpiryStr}" title="Edit expiry date"><i class="fas fa-calendar-edit"></i> Edit Expiry</button>`;
     }
     
+    // Lock/unlock buttons - available to super admin for all block statuses
+    if (isSuperAdmin()) {
+        lockButton = isLocked 
+            ? `<button class="btn-cancel" data-block-id="${block.id}" data-locked="true" title="Unlock this block"><i class="fas fa-unlock"></i> Unlock</button>`
+            : `<button class="btn-cancel" data-block-id="${block.id}" data-locked="false" title="Lock this block"><i class="fas fa-lock"></i> Lock</button>`;
+    }
+    
+    // Delete button - restrictions based on status and whether block has been used
     if (status === 'active') {
-        // Active blocks cannot be locked/unlocked
-        lockButton = `<button class="btn-cancel" disabled title="Cannot lock/unlock active concessions"><i class="fas fa-lock"></i> Lock</button>`;
         // Active blocks can only be deleted if no entries have been used (and only by super admin)
         deleteButton = (!isSuperAdmin() || hasBeenUsed)
             ? `<button class="btn-delete" disabled title="${!isSuperAdmin() ? 'Only super admin can delete' : 'Cannot delete - concession has been used'}"><i class="fas fa-trash"></i> Delete</button>`
             : `<button class="btn-delete" data-block-id="${block.id}" data-student-id="${studentId}" title="Delete this block"><i class="fas fa-trash"></i> Delete</button>`;
     } else {
-        // Expired and depleted blocks can be locked/unlocked (only by super admin)
-        if (isSuperAdmin()) {
-            lockButton = isLocked 
-                ? `<button class="btn-cancel" data-block-id="${block.id}" data-locked="true" title="Unlock this block"><i class="fas fa-unlock"></i> Unlock</button>`
-                : `<button class="btn-cancel" data-block-id="${block.id}" data-locked="false" title="Lock this block"><i class="fas fa-lock"></i> Lock</button>`;
-        }
-        
         // Expired/depleted blocks can only be deleted if no entries have been used (and only by super admin)
         deleteButton = (!isSuperAdmin() || hasBeenUsed)
             ? `<button class="btn-delete" disabled title="${!isSuperAdmin() ? 'Only super admin can delete' : 'Cannot delete - concession has been used'}"><i class="fas fa-trash"></i> Delete</button>`

--- a/admin/student-database/js/transaction-history/transaction-history-concessions.js
+++ b/admin/student-database/js/transaction-history/transaction-history-concessions.js
@@ -209,9 +209,9 @@ function buildTransactionConcessionItem(block, status, studentId) {
             statusClass = '';
     }
     
-    // Get existing notes for expired/depleted items
+    // Get existing notes for locked blocks (any status) or expired/depleted items
     const existingNotes = block.lockNotes || '';
-    const showNotes = status === 'expired' || status === 'depleted';
+    const showNotes = isLocked || status === 'expired' || status === 'depleted';
     
     let html = `
         <div class="concession-item ${statusClass} ${isLocked ? 'locked' : ''} ${isGifted ? 'gifted' : ''}">


### PR DESCRIPTION
Allow locking of Active concessions blocks, e.g. in the case where a concession block is refunded.