### PR TITLE
Membership checkin improvement

### DIFF
--- a/admin/check-in/js/checkin-concession-display.js
+++ b/admin/check-in/js/checkin-concession-display.js
@@ -74,6 +74,15 @@ async function updateMembershipInfo(student, membershipCheck) {
             <span class="badge badge-yes">Active</span>
         `;
         
+        // Build button HTML - only show Renew button if auto-renew is disabled
+        const renewButtonHtml = membershipCheck.autoRenew ? '' : `
+            <div style="margin-top: 0.75rem;">
+                <button type="button" class="btn-primary btn-purchase" onclick="purchaseMembershipForStudent('${student.id}')">
+                    <i class="fas fa-shopping-cart"></i> Renew Membership
+                </button>
+            </div>
+        `;
+        
         membershipDetails.innerHTML = `
             <div style="padding: 0.75rem; background: var(--bg-success-light); border-radius: 4px; border-left: 4px solid var(--success);">
                 <div style="font-weight: 500; margin-bottom: 0.5rem;">
@@ -84,11 +93,7 @@ async function updateMembershipInfo(student, membershipCheck) {
                     ${daysRemaining} ${daysRemaining === 1 ? 'day' : 'days'} remaining
                 </div>
             </div>
-            <div style="margin-top: 0.75rem;">
-                <button type="button" class="btn-primary btn-purchase" onclick="purchaseMembershipForStudent('${student.id}')">
-                    <i class="fas fa-shopping-cart"></i> Renew Membership
-                </button>
-            </div>
+            ${renewButtonHtml}
         `;
         
         // Enable membership entry option

--- a/admin/check-in/js/checkin-concession-display.js
+++ b/admin/check-in/js/checkin-concession-display.js
@@ -153,7 +153,7 @@ async function updateMembershipInfo(student, membershipCheck) {
 /**
  * Open membership assignment modal for a student (called from check-in UI)
  */
-function purchaseMembershipForStudent(studentId) {
+async function purchaseMembershipForStudent(studentId) {
     const student = getSelectedStudent();
     if (!student || student.id !== studentId) {
         window.showSnackbar('Student not found', 'error');
@@ -166,7 +166,18 @@ function purchaseMembershipForStudent(studentId) {
     // Get the selected check-in date
     const selectedDate = getSelectedCheckinDate();
     
-    // Open membership assignment modal with student ID, callback, parent modal ID, student object, and check-in date
+    // Check if student has an active membership to determine default start date
+    let defaultStartDate = new Date(); // Default to today
+    
+    if (student.membershipExpiryDate) {
+        // Student has an active membership - set to day after expiry
+        const expiryDate = student.membershipExpiryDate.toDate();
+        const dayAfterExpiry = new Date(expiryDate);
+        dayAfterExpiry.setDate(dayAfterExpiry.getDate() + 1);
+        defaultStartDate = dayAfterExpiry;
+    }
+    
+    // Open membership assignment modal with student ID, callback, parent modal ID, student object, and default start date
     window.openMembershipAssignmentModal(student.id, async (result) => {
         // Fetch fresh student data from Firestore
         const studentDoc = await firebase.firestore().collection('students').doc(student.id).get();
@@ -189,7 +200,7 @@ function purchaseMembershipForStudent(studentId) {
         if (membershipCheck.isImprover) {
             await updateMembershipInfo(freshStudentData, membershipCheck);
         }
-    }, 'checkin-modal', student, selectedDate);
+    }, 'checkin-modal', student, defaultStartDate);
 }
 
 // Expose functions globally

--- a/admin/check-in/js/membership-assignment-modal.js
+++ b/admin/check-in/js/membership-assignment-modal.js
@@ -284,21 +284,6 @@ async function showMembershipStudentInfo(studentId) {
         
         document.getElementById('membership-student-info').style.display = 'block';
         
-        // Check for existing active membership
-        if (student.activeMembershipId) {
-            const activeMembershipDoc = await firebase.firestore()
-                .collection('memberships')
-                .doc(student.activeMembershipId)
-                .get();
-            
-            if (activeMembershipDoc.exists) {
-                const activeMembership = activeMembershipDoc.data();
-                if (activeMembership.status === 'active') {
-                    window.showSnackbar('Warning: This student already has an active membership. This will replace it.', 'warning');
-                }
-            }
-        }
-        
     } catch (error) {
         console.error('Error loading student info:', error);
     }

--- a/admin/check-in/js/membership-validation.js
+++ b/admin/check-in/js/membership-validation.js
@@ -51,13 +51,28 @@ async function checkStudentMembership(studentId, checkinDate = null) {
             expiryDate.setHours(23, 59, 59, 999);
             
             if (expiryDate >= validationDate) {
-                // Has active membership
+                // Has active membership - fetch membership details for auto-renew status
+                let autoRenew = false;
+                try {
+                    const membershipDoc = await firebase.firestore()
+                        .collection('memberships')
+                        .doc(studentData.activeMembershipId)
+                        .get();
+                    
+                    if (membershipDoc.exists) {
+                        autoRenew = membershipDoc.data().autoRenew === true;
+                    }
+                } catch (error) {
+                    console.error('Error fetching membership details:', error);
+                }
+                
                 return {
                     isImprover: true,
                     hasActiveMembership: true,
                     canCheckIn: true,
                     membershipId: studentData.activeMembershipId,
                     expiryDate: studentData.membershipExpiryDate,
+                    autoRenew: autoRenew,
                     source: 'membership'
                 };
             } else {


### PR DESCRIPTION
Enhancements made to membership purchasing via check-in modal:
- If student has active, auto-renewing membership, the Renew button is hidden.
- When Renew button is clicked and there's an active membership, set date picker to the day after the membership expiry, else set date picker date to "today".
- Remove redundant "this membership purchase will replace existing membership" snackbar.