### PR TITLE
Switch between membership and concessions for improvers without a membership

### DIFF
--- a/admin/check-in/js/checkin-concession-display.js
+++ b/admin/check-in/js/checkin-concession-display.js
@@ -139,6 +139,26 @@ async function updateMembershipInfo(student, membershipCheck) {
             membershipRadio.parentElement.style.opacity = '0.5';
         }
         
+        // Check concession balance to enable/disable concession radio button
+        const concessionRadio = document.getElementById('entry-concession');
+        if (concessionRadio) {
+            try {
+                const concessionData = await getConcessionData(student.id);
+                if (concessionData.totalBalance > 0) {
+                    concessionRadio.disabled = false;
+                    concessionRadio.parentElement.style.opacity = '1';
+                } else {
+                    concessionRadio.disabled = true;
+                    concessionRadio.parentElement.style.opacity = '0.5';
+                }
+            } catch (error) {
+                console.error('Error checking concession balance:', error);
+                // Default to disabled if error
+                concessionRadio.disabled = true;
+                concessionRadio.parentElement.style.opacity = '0.5';
+            }
+        }
+        
         // Default to casual entry if not in edit mode
         if (!isEditMode()) {
             const casualEntryRadio = document.getElementById('entry-casual');
@@ -206,13 +226,24 @@ async function purchaseMembershipForStudent(studentId) {
 // Expose functions globally
 window.purchaseMembershipForStudent = purchaseMembershipForStudent;
 window.updateMembershipInfo = updateMembershipInfo;
+window.updateConcessionInfo = updateConcessionInfo;
 
 /**
  * Update concession info display
+ * @param {Object} student - Student object
+ * @param {boolean} setDefaults - Whether to set default radio selections (default: true)
  */
-async function updateConcessionInfo(student) {
+async function updateConcessionInfo(student, setDefaults = true) {
     const balanceSpan = document.getElementById('concession-balance');
     const blocksDiv = document.getElementById('concession-blocks');
+    const membershipInfo = document.getElementById('membership-info');
+    const concessionInfo = document.getElementById('concession-info');
+    const purchaseSection = document.querySelector('.purchase-section');
+    
+    // Hide membership info, show concession info
+    if (membershipInfo) membershipInfo.style.display = 'none';
+    if (purchaseSection) purchaseSection.style.display = 'block';
+    if (concessionInfo) concessionInfo.style.display = 'block';
     
     // Show loading state
     balanceSpan.textContent = 'Loading...';
@@ -249,6 +280,7 @@ async function updateConcessionInfo(student) {
         const freeEntryRadio = document.getElementById('entry-free');
         const freeEntryReasonSelect = document.getElementById('free-entry-reason');
         
+        // Enable concession radio if student has a balance (works for both improvers and non-improvers)
         if (concessionData.totalBalance > 0) {
             concessionRadio.disabled = false;
             concessionRadio.parentElement.style.opacity = '1';
@@ -264,8 +296,8 @@ async function updateConcessionInfo(student) {
             membershipRadio.parentElement.style.opacity = '0.5';
         }
         
-        // Set defaults only if NOT in edit mode
-        if (!isEditMode()) {
+        // Set defaults only if NOT in edit mode AND setDefaults is true
+        if (!isEditMode() && setDefaults) {
             // If student is a crew member, default to free entry with crew member reason
             if (student.crewMember === true) {
                 freeEntryRadio.checked = true;

--- a/admin/check-in/js/checkin-form.js
+++ b/admin/check-in/js/checkin-form.js
@@ -60,6 +60,32 @@ function setupEntryTypeListeners() {
                 onlinePaymentMessages.innerHTML = '';
             }
             
+            // Handle membership/concession info toggle for improvers without active membership
+            const student = getSelectedStudent();
+            if (student) {
+                const membershipCheck = await window.checkStudentMembership(student.id, getSelectedCheckinDate());
+                if (membershipCheck && membershipCheck.isImprover && !membershipCheck.hasActiveMembership) {
+                    const membershipInfo = document.getElementById('membership-info');
+                    const concessionInfo = document.getElementById('concession-info');
+                    
+                    if (radio.value === 'concession') {
+                        // Load concession data FIRST while membership container is still visible
+                        if (typeof window.updateConcessionInfo === 'function') {
+                            // Pass false to prevent setting defaults (avoid infinite loop)
+                            await window.updateConcessionInfo(student, false);
+                        }
+                        
+                        // Then swap containers after data is loaded (prevents modal resize)
+                        if (concessionInfo) concessionInfo.style.display = 'block';
+                        if (membershipInfo) membershipInfo.style.display = 'none';
+                    } else {
+                        // Swap containers immediately to prevent modal resize
+                        if (membershipInfo) membershipInfo.style.display = 'block';
+                        if (concessionInfo) concessionInfo.style.display = 'none';
+                    }
+                }
+            }
+            
             // Show appropriate section based on selection
             if (radio.value === 'casual' || radio.value === 'casual-student') {
                 paymentSection.style.display = 'block';


### PR DESCRIPTION
On check-in, if an Improver has no active membership:
1. Check in modal defaults to Casual Rate (existing behaviour)
2. If admin chooses Use Concession, then the Membership Info container is replaced by the Concession Balance container on the check-in modal (new behaviour).